### PR TITLE
Add option for native optimizations in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,8 @@ add_dependencies(rayleigh run_param_header)
 
 target_include_directories(rayleigh PRIVATE ${PROJECT_SOURCE_DIR}/src/Include ${CMAKE_CURRENT_BINARY_DIR})
 
-set(RAYLEIGH_CPU_OPTIMIZATIONS "none" CACHE PATH "Specify a CPU architecture to build for. Currently only 'native' or 'none' are supported.")
+set(RAYLEIGH_CPU_OPTIMIZATIONS "none" CACHE STRING "Specify a CPU architecture to build for. Currently only 'native' or 'none' are supported.")
+set_property(CACHE RAYLEIGH_CPU_OPTIMIZATIONS PROPERTY STRINGS "none" "native")
 
 if (RAYLEIGH_CPU_OPTIMIZATIONS STREQUAL "native")
   if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,23 @@ add_dependencies(rayleigh run_param_header)
 
 target_include_directories(rayleigh PRIVATE ${PROJECT_SOURCE_DIR}/src/Include ${CMAKE_CURRENT_BINARY_DIR})
 
+set(RAYLEIGH_CPU_OPTIMIZATIONS "none" CACHE PATH "Specify a CPU architecture to build for. Currently only 'native' or 'none' are supported.")
+
+if (RAYLEIGH_CPU_OPTIMIZATIONS STREQUAL "native")
+  if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(rayleigh PRIVATE -march=native)
+    message(STATUS "enabling native optimizations")
+  elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+    target_compile_options(rayleigh PRIVATE -xHost)
+  else()
+    message(FATAL_ERROR "For your compiler no native optimizations are automatically detected. Please specify compiler flags manually and set 'CPU_OPTIMIZATIONS' to 'none'")
+  endif()
+elseif (RAYLEIGH_CPU_OPTIMIZATIONS STREQUAL "none")
+  # do nothing, respect manually set compiler flags
+else()
+  message(FATAL_ERROR "Only 'native' and 'none' are supported for parameter 'CPU_OPTIMIZATIONS'")
+endif()
+
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   target_compile_definitions(rayleigh PRIVATE GNU_COMPILER)
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")


### PR DESCRIPTION
Add a cmake variable that controls whether to add CPU specific optimizations. Currently only 'native' or 'none' are supported. If 'native' is set it overrides any architecture parameter in CMAKE_FORTRAN_FLAGS, so 'none' needs to be selected by default to allow the user to e.g. specify `-DCMAKE_FORTRAN_FLAGS='-O3 -march=avx2'` if  `native` is not wanted.